### PR TITLE
Updating Webex Teams Version Handling

### DIFF
--- a/Cisco/Webex Teams.download.recipe
+++ b/Cisco/Webex Teams.download.recipe
@@ -51,7 +51,7 @@
 				<key>input_plist_path</key>
 				<string>%pathname%/Webex Teams.app/Contents/Info.plist</string>
 				<key>plist_version_key</key>
-				<string>CFBundleVersion</string>
+				<string>CFBundleShortVersionString</string>
 			</dict>
 			<key>Processor</key>
 			<string>Versioner</string>

--- a/Cisco/Webex Teams.munki.recipe
+++ b/Cisco/Webex Teams.munki.recipe
@@ -58,7 +58,7 @@
 				<key>repo_subdirectory</key>
 				<string>%MUNKI_REPO_SUBDIR%</string>
 				<key>version_comparison_key</key>
-				<string>CFBundleVersion</string>
+				<string>CFBundleShortVersionString</string>
 			</dict>
 			<key>Processor</key>
 			<string>MunkiImporter</string>

--- a/Cisco/Webex Teams.munki.recipe
+++ b/Cisco/Webex Teams.munki.recipe
@@ -41,18 +41,6 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>additional_pkginfo</key>
-				<dict>
-					<key>version</key>
-					<string>%version%</string>
-				</dict>
-			</dict>
-			<key>Processor</key>
-			<string>MunkiPkginfoMerger</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
 				<key>pkg_path</key>
 				<string>%pathname%</string>
 				<key>repo_subdirectory</key>

--- a/Cisco/Webex Teams.munki.recipe
+++ b/Cisco/Webex Teams.munki.recipe
@@ -21,7 +21,7 @@
 				<string>testing</string>
 			</array>
 			<key>description</key>
-			<string> </string>
+			<string>The easy-to-use collaboration solution that keeps people and teamwork connected anytime, anywhere.</string>
 			<key>developer</key>
 			<string>Cisco</string>
 			<key>display_name</key>


### PR DESCRIPTION
Improving version handling so Munki can see the marketing/documentation versioning information rather than the (apparent) build number.