### PR TITLE
Update Webex Teams.download.recipe

### DIFF
--- a/Cisco/Webex Teams.download.recipe
+++ b/Cisco/Webex Teams.download.recipe
@@ -11,7 +11,7 @@
 	<key>Input</key>
 	<dict>
 		<key>DOWNLOAD_URL</key>
-		<string>http://www.webex.com/downloads/WebexTeams.dmg</string>
+		<string>https://binaries.webex.com/WebexTeamsDesktop-MACOS-Gold/WebexTeams.dmg</string>
 		<key>NAME</key>
 		<string>Webex Teams</string>
 	</dict>


### PR DESCRIPTION
The static URL to download from has changed.  Viewing the content of `curl https://www.webex.com/downloads.html` shows the old URL is commented out and now uses a new URL for the Teams app:

```
        if (osType === 'macOS') {
          $('.meetings-app, .teams-app').text('Download for macOS').addClass("osx");
          meetingsAppUrl = 'https://akamaicdn.webex.com/client/webexapp.dmg';
          //teamsAppUrl = 'http://www.webex.com/downloads/WebexTeams.dmg';
          teamsAppUrl = 'https://binaries.webex.com/WebexTeamsDesktop-MACOS-Gold/WebexTeams.dmg';
        }
```

This PR updates the download URL.