### PR TITLE
Update Webex Teams.download.recipe

### DIFF
--- a/Cisco/Webex Teams.download.recipe
+++ b/Cisco/Webex Teams.download.recipe
@@ -38,7 +38,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%pathname%/Webex Teams.app</string>
+				<string>%pathname%/Webex.app</string>
 				<key>requirement</key>
 				<string>identifier "Cisco-Systems.Spark" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = DE8Y96K9QP</string>
 			</dict>
@@ -49,7 +49,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%pathname%/Webex Teams.app/Contents/Info.plist</string>
+				<string>%pathname%/Webex.app/Contents/Info.plist</string>
 				<key>plist_version_key</key>
 				<string>CFBundleShortVersionString</string>
 			</dict>


### PR DESCRIPTION
Webex Teams rebranded to just be named Webex. This update reflects that change in the download recipe.

For those that already use Webex Teams they will need to deal with the application name change on the client in a way they see fit.  I'm adding a `postinstall_script` to `rm -r /Applications/Webex\ Teams.app`.

![image](https://user-images.githubusercontent.com/1416288/101784841-a702a680-3ac1-11eb-8c64-693747fb782d.png)
