### PR TITLE
Remove unused BUNDLE_ID input var

### DIFF
--- a/Cisco/Cisco Spark.pkg.recipe
+++ b/Cisco/Cisco Spark.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.precursorca.pkg.CiscoSpark</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>Cisco-Systems.Spark</string>
 		<key>NAME</key>
 		<string>Cisco Spark</string>
 	</dict>

--- a/Cisco/Webex Teams.pkg.recipe
+++ b/Cisco/Webex Teams.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.precursorca.pkg.WebexTeams</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>Cisco-Systems.Spark</string>
 		<key>NAME</key>
 		<string>Webex Teams</string>
 	</dict>

--- a/QuickBooks/QuickBooks.pkg.recipe
+++ b/QuickBooks/QuickBooks.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.precursorca.pkg.QuickBooks</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.intuit.QBOClient</string>
 		<key>NAME</key>
 		<string>QuickBooks</string>
 	</dict>

--- a/Sloth/Sloth.pkg.recipe
+++ b/Sloth/Sloth.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.precursorca.pkg.Sloth</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>org.sveinbjorn.Sloth</string>
 		<key>NAME</key>
 		<string>Sloth</string>
 	</dict>

--- a/St. Clair Software/Go64.pkg.recipe
+++ b/St. Clair Software/Go64.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.precursorca.pkg.Go64</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.stclairsoft.Go64</string>
 		<key>NAME</key>
 		<string>Go64</string>
 	</dict>

--- a/Vectorworks/Vectorworks 2018 Installer.pkg.recipe
+++ b/Vectorworks/Vectorworks 2018 Installer.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.precursorca.pkg.Vectorworks2018Installer</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>net.nemetschek.vectorworksinstaller</string>
 		<key>NAME</key>
 		<string>Vectorworks 2018 Installer</string>
 	</dict>

--- a/Vectorworks/Vectorworks 2020 Installer.pkg.recipe
+++ b/Vectorworks/Vectorworks 2020 Installer.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.precursorca.pkg.Vectorworks2020Installer</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>net.nemetschek.vectorworksinstaller</string>
 		<key>NAME</key>
 		<string>Vectorworks 2020 Installer</string>
 	</dict>


### PR DESCRIPTION
This pull request removes unused instances of `BUNDLE_ID` from recipe input variables, which will help reduce confusion by new AutoPkg users and simplify overrides created from this point on.

Making `BUNDLE_ID` available as an input variable is a common practice in AutoPkg recipes that use the [PkgCreator](https://github.com/autopkg/autopkg/wiki/Processor-PkgCreator) processor ([example](https://github.com/autopkg/homebysix-recipes/blob/4fec9244a3af0f9b7c8f61f35a5cd7f4622fb162/soma-zone/LaunchControl.pkg.recipe#L40-L41)). It's likely that these recipes transitioned from PkgCreator to the more streamlined [AppPkgCreator](https://github.com/autopkg/autopkg/wiki/Processor-AppPkgCreator) processor some time ago, but the now-unused input variable for `BUNDLE_ID` was never removed.

Recipe run output is included below for all changed recipes (excluding jss and install recipe types). Any run failures are very likely to be unrelated to this change.

## ✅ Cisco/Cisco Spark.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/precursorca-recipes/Cisco/Cisco\ Spark.pkg.recipe
Processing repos/precursorca-recipes/Cisco/Cisco Spark.pkg.recipe...
URLDownloader
{'Input': {'filename': 'Cisco Spark.dmg',
           'url': 'https://download.ciscospark.com/mac/CiscoSpark.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.precursorca.pkg.CiscoSpark/downloads/Cisco Spark.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.precursorca.pkg.CiscoSpark/downloads/Cisco '
                        'Spark.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.precursorca.pkg.CiscoSpark/downloads/Cisco '
                         'Spark.dmg/Cisco Spark.app',
           'requirement': 'identifier "Cisco-Systems.Spark" and anchor apple '
                          'generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'DE8Y96K9QP'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.precursorca.pkg.CiscoSpark/downloads/Cisco Spark.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.MNPRL2/Cisco Spark.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.MNPRL2/Cisco Spark.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.MNPRL2/Cisco Spark.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '~/Library/AutoPkg/Cache/com.github.precursorca.pkg.CiscoSpark/downloads/Cisco '
                               'Spark.dmg/Cisco Spark.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleVersion'}}
Versioner: Mounted disk image ~/Library/AutoPkg/Cache/com.github.precursorca.pkg.CiscoSpark/downloads/Cisco Spark.dmg
Versioner: Found version 8481 in file /private/tmp/dmg.ZyhFym/Cisco Spark.app/Contents/Info.plist
{'Output': {'version': '8481'}}
AppPkgCreator
{'Input': {'version': '8481'}}
AppPkgCreator: Mounted disk image ~/Library/AutoPkg/Cache/com.github.precursorca.pkg.CiscoSpark/downloads/Cisco Spark.dmg
AppPkgCreator: Using path '/private/tmp/dmg.wJHZzI/Cisco Spark.app' matched from globbed '/private/tmp/dmg.wJHZzI/*.app'.
AppPkgCreator: BundleID: Cisco-Systems.Spark
AppPkgCreator: Copied /private/tmp/dmg.wJHZzI/Cisco Spark.app to ~/Library/AutoPkg/Cache/com.github.precursorca.pkg.CiscoSpark/payload/Applications/Cisco Spark.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'Cisco-Systems.Spark',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.precursorca.pkg.CiscoSpark/Cisco '
                                                                    'Spark-8481.pkg',
                                                        'version': '8481'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '8481'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.precursorca.pkg.CiscoSpark/receipts/Cisco Spark.pkg-receipt-20210213-234512.plist

The following packages were built:
    Identifier           Version  Pkg Path                                                                                         
    ----------           -------  --------                                                                                         
    Cisco-Systems.Spark  8481     ~/Library/AutoPkg/Cache/com.github.precursorca.pkg.CiscoSpark/Cisco Spark-8481.pkg  
```

## ❌ Cisco/Webex Teams.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/precursorca-recipes/Cisco/Webex\ Teams.pkg.recipe
Processing repos/precursorca-recipes/Cisco/Webex Teams.pkg.recipe...
URLDownloader
{'Input': {'filename': 'Webex Teams.dmg',
           'url': 'https://binaries.webex.com/WebexTeamsDesktop-MACOS-Gold/WebexTeams.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.precursorca.pkg.WebexTeams/downloads/Webex Teams.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.precursorca.pkg.WebexTeams/downloads/Webex '
                        'Teams.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.precursorca.pkg.WebexTeams/downloads/Webex '
                         'Teams.dmg/Webex Teams.app',
           'requirement': 'identifier "Cisco-Systems.Spark" and anchor apple '
                          'generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'DE8Y96K9QP'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.precursorca.pkg.WebexTeams/downloads/Webex Teams.dmg
Receipt written to ~/Library/AutoPkg/Cache/com.github.precursorca.pkg.WebexTeams/receipts/Webex Teams.pkg-receipt-20210213-234519.plist

The following recipes failed:
    repos/precursorca-recipes/Cisco/Webex Teams.pkg.recipe
        Error in com.github.precursorca.pkg.WebexTeams: Processor: CodeSignatureVerifier: Error: Error processing path '/private/tmp/dmg.ucnjGJ/Webex Teams.app' with glob. 

Nothing downloaded, packaged or imported.
```

## ❌ QuickBooks/QuickBooks.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/precursorca-recipes/QuickBooks/QuickBooks.pkg.recipe
Processing repos/precursorca-recipes/QuickBooks/QuickBooks.pkg.recipe...
URLDownloader
{'Input': {'filename': 'QuickBooks.dmg',
           'url': 'https://http-download.intuit.com/http.intuit/CMO/qbo_client_web/static/release/mac/latest/QuickBooks.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.precursorca.pkg.QuickBooks/downloads/QuickBooks.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.precursorca.pkg.QuickBooks/downloads/QuickBooks.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.precursorca.pkg.QuickBooks/downloads/QuickBooks.dmg/QuickBooks.app',
           'requirement': 'identifier "com.intuit.QBOClient" and anchor apple '
                          'generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'G4SSPX3CBL'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.precursorca.pkg.QuickBooks/downloads/QuickBooks.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.JqtWZg/QuickBooks.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.JqtWZg/QuickBooks.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.JqtWZg/QuickBooks.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '~/Library/AutoPkg/Cache/com.github.precursorca.pkg.QuickBooks/downloads/QuickBooks.dmg/QuickBooks.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleShortVersionString'}}
Versioner: Mounted disk image ~/Library/AutoPkg/Cache/com.github.precursorca.pkg.QuickBooks/downloads/QuickBooks.dmg
Versioner: Found version 4.3.0-82 in file /private/tmp/dmg.YMDla8/QuickBooks.app/Contents/Info.plist
{'Output': {'version': '4.3.0-82'}}
AppPkgCreator
{'Input': {'version': '4.3.0-82'}}
AppPkgCreator: Mounted disk image ~/Library/AutoPkg/Cache/com.github.precursorca.pkg.QuickBooks/downloads/QuickBooks.dmg
AppPkgCreator: Using path '/private/tmp/dmg.2fRaqK/QuickBooks.app' matched from globbed '/private/tmp/dmg.2fRaqK/*.app'.
AppPkgCreator: BundleID: com.intuit.QBOClient
AppPkgCreator: Copied /private/tmp/dmg.2fRaqK/QuickBooks.app to ~/Library/AutoPkg/Cache/com.github.precursorca.pkg.QuickBooks/payload/Applications/QuickBooks.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
Receipt written to ~/Library/AutoPkg/Cache/com.github.precursorca.pkg.QuickBooks/receipts/QuickBooks.pkg-receipt-20210213-234531.plist

The following recipes failed:
    repos/precursorca-recipes/QuickBooks/QuickBooks.pkg.recipe
        Error in com.github.precursorca.pkg.QuickBooks: Processor: AppPkgCreator: Error: Invalid version component "0-82"

Nothing downloaded, packaged or imported.
```

## ✅ Sloth/Sloth.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/precursorca-recipes/Sloth/Sloth.pkg.recipe
Processing repos/precursorca-recipes/Sloth/Sloth.pkg.recipe...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'https://sveinbjorn.org/files/appcasts/SlothAppcast.xml'}}
SparkleUpdateInfoProvider: Version retrieved from appcast: 256
SparkleUpdateInfoProvider: User-facing version retrieved from appcast: 3.0.1
SparkleUpdateInfoProvider: Found URL https://sveinbjorn.org/files/software/sloth/sloth-3.0.1.zip
{'Output': {'url': 'https://sveinbjorn.org/files/software/sloth/sloth-3.0.1.zip',
            'version': '3.0.1'}}
URLDownloader
{'Input': {'filename': 'Sloth-3.0.1.zip',
           'url': 'https://sveinbjorn.org/files/software/sloth/sloth-3.0.1.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.precursorca.pkg.Sloth/downloads/Sloth-3.0.1.zip
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.precursorca.pkg.Sloth/downloads/Sloth-3.0.1.zip'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {'archive_path': '~/Library/AutoPkg/Cache/com.github.precursorca.pkg.Sloth/downloads/Sloth-3.0.1.zip',
           'destination_path': '~/Library/AutoPkg/Cache/com.github.precursorca.pkg.Sloth/Sloth',
           'purge_destination': True}}
Unarchiver: Guessed archive format 'zip' from filename Sloth-3.0.1.zip
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.precursorca.pkg.Sloth/downloads/Sloth-3.0.1.zip to ~/Library/AutoPkg/Cache/com.github.precursorca.pkg.Sloth/Sloth
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.precursorca.pkg.Sloth/Sloth/Sloth.app',
           'requirement': 'anchor apple generic and identifier '
                          '"org.sveinbjorn.Sloth" and (certificate '
                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
                          'or certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = "5WX26Y89JP")'}}
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.precursorca.pkg.Sloth/Sloth/Sloth.app: valid on disk
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.precursorca.pkg.Sloth/Sloth/Sloth.app: satisfies its Designated Requirement
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.precursorca.pkg.Sloth/Sloth/Sloth.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
AppPkgCreator
{'Input': {'app_path': '~/Library/AutoPkg/Cache/com.github.precursorca.pkg.Sloth/Sloth/Sloth.app',
           'version': '3.0.1'}}
AppPkgCreator: BundleID: org.sveinbjorn.Sloth
AppPkgCreator: Copied ~/Library/AutoPkg/Cache/com.github.precursorca.pkg.Sloth/Sloth/Sloth.app to ~/Library/AutoPkg/Cache/com.github.precursorca.pkg.Sloth/payload/Applications/Sloth.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'org.sveinbjorn.Sloth',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.precursorca.pkg.Sloth/Sloth-3.0.1.pkg',
                                                        'version': '3.0.1'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '3.0.1'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.precursorca.pkg.Sloth/receipts/Sloth.pkg-receipt-20210213-234535.plist

The following packages were built:
    Identifier            Version  Pkg Path                                                                               
    ----------            -------  --------                                                                               
    org.sveinbjorn.Sloth  3.0.1    ~/Library/AutoPkg/Cache/com.github.precursorca.pkg.Sloth/Sloth-3.0.1.pkg  
```

## ✅ St. Clair Software/Go64.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/precursorca-recipes/St.\ Clair\ Software/Go64.pkg.recipe
Processing repos/precursorca-recipes/St. Clair Software/Go64.pkg.recipe...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'https://www.stclairsoft.com/cgi-bin/sparkle.cgi?GO'}}
SparkleUpdateInfoProvider: Version retrieved from appcast: 1301
SparkleUpdateInfoProvider: User-facing version retrieved from appcast: 1.3
SparkleUpdateInfoProvider: Found URL https://www.stclairsoft.com/download/Go64-1.3.zip
{'Output': {'url': 'https://www.stclairsoft.com/download/Go64-1.3.zip',
            'version': '1.3'}}
URLDownloader
{'Input': {'filename': 'Go64-1.3.zip',
           'url': 'https://www.stclairsoft.com/download/Go64-1.3.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.precursorca.pkg.Go64/downloads/Go64-1.3.zip
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.precursorca.pkg.Go64/downloads/Go64-1.3.zip'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {'archive_path': '~/Library/AutoPkg/Cache/com.github.precursorca.pkg.Go64/downloads/Go64-1.3.zip',
           'destination_path': '~/Library/AutoPkg/Cache/com.github.precursorca.pkg.Go64/Go64',
           'purge_destination': True}}
Unarchiver: Guessed archive format 'zip' from filename Go64-1.3.zip
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.precursorca.pkg.Go64/downloads/Go64-1.3.zip to ~/Library/AutoPkg/Cache/com.github.precursorca.pkg.Go64/Go64
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.precursorca.pkg.Go64/Go64/Go64.app',
           'requirement': 'anchor apple generic and identifier '
                          '"com.stclairsoft.Go64" and (certificate '
                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
                          'or certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = "7HK42V8R9D")'}}
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.precursorca.pkg.Go64/Go64/Go64.app: valid on disk
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.precursorca.pkg.Go64/Go64/Go64.app: satisfies its Designated Requirement
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.precursorca.pkg.Go64/Go64/Go64.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
AppPkgCreator
{'Input': {'app_path': '~/Library/AutoPkg/Cache/com.github.precursorca.pkg.Go64/Go64/Go64.app',
           'version': '1.3'}}
AppPkgCreator: BundleID: com.stclairsoft.Go64
AppPkgCreator: Copied ~/Library/AutoPkg/Cache/com.github.precursorca.pkg.Go64/Go64/Go64.app to ~/Library/AutoPkg/Cache/com.github.precursorca.pkg.Go64/payload/Applications/Go64.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'com.stclairsoft.Go64',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.precursorca.pkg.Go64/Go64-1.3.pkg',
                                                        'version': '1.3'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '1.3'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.precursorca.pkg.Go64/receipts/Go64.pkg-receipt-20210213-234540.plist

The following packages were built:
    Identifier            Version  Pkg Path                                                                           
    ----------            -------  --------                                                                           
    com.stclairsoft.Go64  1.3      ~/Library/AutoPkg/Cache/com.github.precursorca.pkg.Go64/Go64-1.3.pkg  
```

## ✅ Vectorworks/Vectorworks 2018 Installer.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/precursorca-recipes/Vectorworks/Vectorworks\ 2018\ Installer.pkg.recipe
Processing repos/precursorca-recipes/Vectorworks/Vectorworks 2018 Installer.pkg.recipe...
URLDownloader
{'Input': {'filename': 'Vectorworks 2018 Installer.dmg',
           'url': 'http://release.vectorworks.net/nnapub/mac/2018/SP0/389445/NNA/eng/installer5/Vectorworks-2018-Viewer.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.precursorca.pkg.Vectorworks2018Installer/downloads/Vectorworks 2018 Installer.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.precursorca.pkg.Vectorworks2018Installer/downloads/Vectorworks '
                        '2018 Installer.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.precursorca.pkg.Vectorworks2018Installer/downloads/Vectorworks '
                         '2018 Installer.dmg/Vectorworks 2018 Installer.app',
           'requirement': 'identifier "net.nemetschek.vectorworksinstaller" '
                          'and anchor apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'LFNG3Q6WX2'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.precursorca.pkg.Vectorworks2018Installer/downloads/Vectorworks 2018 Installer.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.9vDHJe/Vectorworks 2018 Installer.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.9vDHJe/Vectorworks 2018 Installer.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.9vDHJe/Vectorworks 2018 Installer.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '~/Library/AutoPkg/Cache/com.github.precursorca.pkg.Vectorworks2018Installer/downloads/Vectorworks '
                               '2018 Installer.dmg/Vectorworks 2018 '
                               'Installer.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleShortVersionString'}}
Versioner: Mounted disk image ~/Library/AutoPkg/Cache/com.github.precursorca.pkg.Vectorworks2018Installer/downloads/Vectorworks 2018 Installer.dmg
Versioner: Found version 23.0.0 in file /private/tmp/dmg.VjePN2/Vectorworks 2018 Installer.app/Contents/Info.plist
{'Output': {'version': '23.0.0'}}
AppPkgCreator
{'Input': {'version': '23.0.0'}}
AppPkgCreator: Mounted disk image ~/Library/AutoPkg/Cache/com.github.precursorca.pkg.Vectorworks2018Installer/downloads/Vectorworks 2018 Installer.dmg
AppPkgCreator: Using path '/private/tmp/dmg.1J4lGV/Vectorworks 2018 Installer.app' matched from globbed '/private/tmp/dmg.1J4lGV/*.app'.
AppPkgCreator: BundleID: net.nemetschek.vectorworksinstaller
AppPkgCreator: Copied /private/tmp/dmg.1J4lGV/Vectorworks 2018 Installer.app to ~/Library/AutoPkg/Cache/com.github.precursorca.pkg.Vectorworks2018Installer/payload/Applications/Vectorworks 2018 Installer.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'net.nemetschek.vectorworksinstaller',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.precursorca.pkg.Vectorworks2018Installer/Vectorworks '
                                                                    '2018 '
                                                                    'Installer-23.0.0.pkg',
                                                        'version': '23.0.0'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '23.0.0'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.precursorca.pkg.Vectorworks2018Installer/receipts/Vectorworks 2018 Installer.pkg-receipt-20210213-234629.plist

The following packages were built:
    Identifier                           Version  Pkg Path                                                                                                                        
    ----------                           -------  --------                                                                                                                        
    net.nemetschek.vectorworksinstaller  23.0.0   ~/Library/AutoPkg/Cache/com.github.precursorca.pkg.Vectorworks2018Installer/Vectorworks 2018 Installer-23.0.0.pkg  
```

## ❌ Vectorworks/Vectorworks 2020 Installer.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/precursorca-recipes/Vectorworks/Vectorworks\ 2020\ Installer.pkg.recipe
Processing repos/precursorca-recipes/Vectorworks/Vectorworks 2020 Installer.pkg.recipe...
URLDownloader
{'Input': {'filename': 'Vectorworks 2020 Installer.dmg',
           'url': 'http://release.vectorworks.net/latest/Vectorworks/2020-NNA-eng-mac-viewer'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.precursorca.pkg.Vectorworks2020Installer/downloads/Vectorworks 2020 Installer.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.precursorca.pkg.Vectorworks2020Installer/downloads/Vectorworks '
                        '2020 Installer.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.precursorca.pkg.Vectorworks2020Installer/downloads/Vectorworks '
                         '2020 Installer.dmg/Vectorworks 2020 Installer.app',
           'requirement': 'identifier "net.nemetschek.vectorworksinstaller" '
                          'and anchor apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'LFNG3Q6WX2'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.precursorca.pkg.Vectorworks2020Installer/downloads/Vectorworks 2020 Installer.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.a8V4wt/Vectorworks 2020 Installer.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.a8V4wt/Vectorworks 2020 Installer.app: satisfies its Designated Requirement
CodeSignatureVerifier: test-requirement: code failed to satisfy specified code requirement(s)
Receipt written to ~/Library/AutoPkg/Cache/com.github.precursorca.pkg.Vectorworks2020Installer/receipts/Vectorworks 2020 Installer.pkg-receipt-20210213-234639.plist

The following recipes failed:
    repos/precursorca-recipes/Vectorworks/Vectorworks 2020 Installer.pkg.recipe
        Error in com.github.precursorca.pkg.Vectorworks2020Installer: Processor: CodeSignatureVerifier: Error: Code signature verification failed. Note that all verifications can be disabled by setting the variable DISABLE_CODE_SIGNATURE_VERIFICATION to a non-empty value.

Nothing downloaded, packaged or imported.
```

