### PR TITLE
Add missing Munki repo subdirectory variable

### DIFF
--- a/Privileges/Privileges.munki.recipe
+++ b/Privileges/Privileges.munki.recipe
@@ -107,6 +107,8 @@ exit 0</string>
 			<dict>
 				<key>pkg_path</key>
 				<string>%pkg_path%</string>
+				<key>repo_subdirectory</key>
+				<string>%MUNKI_REPO_SUBDIR%</string>
 			</dict>
 			<key>Processor</key>
 			<string>MunkiImporter</string>


### PR DESCRIPTION
`MUNKI_REPO_SUBDIR` was included as an input variable, but not referenced by MunkiImporter.