### PR TITLE
Moved url to input for mulit arch

### DIFF
--- a/Cisco/Webex.download.recipe
+++ b/Cisco/Webex.download.recipe
@@ -5,13 +5,19 @@
 	<key>Comment</key>
 	<string>Created with Recipe Robot v2.0.0 (https://github.com/homebysix/recipe-robot)</string>
 	<key>Description</key>
-	<string>Downloads the latest version of Webex.</string>
+	<string>Downloads the latest version of Webex.
+Input "url" can be one of two:
+Intel: https://binaries.webex.com/WebexTeamsDesktop-MACOS-Gold/Webex.dmg
+AppleSilicon: https://binaries.webex.com/WebexDesktop-MACOS-Apple-Silicon-Gold/Webex.dmg
+	</string>
 	<key>Identifier</key>
 	<string>com.github.precursorca.download.Webex</string>
 	<key>Input</key>
 	<dict>
 		<key>NAME</key>
 		<string>Webex</string>
+		<key>url</key>
+		<string>https://binaries.webex.com/WebexTeamsDesktop-MACOS-Gold/Webex.dmg</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>1.0.0</string>
@@ -22,8 +28,6 @@
 			<dict>
 				<key>filename</key>
 				<string>%NAME%.dmg</string>
-				<key>url</key>
-				<string>https://binaries.webex.com/WebexTeamsDesktop-MACOS-Gold/Webex.dmg</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>


### PR DESCRIPTION
Added the option to edit the url field.
WebEx has two binaries. One for AS and one for Intel chips.

This would allow the import of both version. Helpful when the next version of AutoPkg hits