### PR TITLE
add essential xml header

### DIFF
--- a/Beta/RemoteUpdateManager.M1.pkg.recipe
+++ b/Beta/RemoteUpdateManager.M1.pkg.recipe
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
@@ -54,7 +55,7 @@
 			<key>Processor</key>
 			<string>com.github.homebysix.BinaryFileVersioner/BinaryFileVersioner</string>
 		</dict>
-	<dict>
+	    <dict>
 			<key>Arguments</key>
 			<dict>
 				<key>split_on</key>


### PR DESCRIPTION
There is a missing xml header in RemoteUpdateManager.M1.pkg.recipe which causes your whole repo to be rejected. For those of us using AutoPkg betas with the recipe-map model, this breaks all autopkg runs until your repo is removed from the repo list. 

This PR fixes it.

I notice that the recipe is in a folder named "beta". This might be a good indication to put recipes that are not ready to go live in a repo outside of the autopkg org, or in a dev branch.