### PR TITLE
Update plist syntax for RemoteUpdateManager.M1.pkg.recipe

### DIFF
--- a/Beta/RemoteUpdateManager.M1.pkg.recipe
+++ b/Beta/RemoteUpdateManager.M1.pkg.recipe
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
@@ -54,7 +55,7 @@
 			<key>Processor</key>
 			<string>com.github.homebysix.BinaryFileVersioner/BinaryFileVersioner</string>
 		</dict>
-	<dict>
+		<dict>
 			<key>Arguments</key>
 			<dict>
 				<key>split_on</key>


### PR DESCRIPTION
The plist was previously unable to parse using plistlib:

```
>>> with open("repos/autopkg/precursorca-recipes/Beta/RemoteUpdateManager.M1.pkg.recipe", "rb") as f:
...   plistlib.load(f)
... 
Traceback (most recent call last):
  File "<stdin>", line 2, in <module>
  File "/Library/ManagedFrameworks/Python/Python3.framework/Versions/3.10/lib/python3.10/plistlib.py", line 869, in load
    raise InvalidFileException()
plistlib.InvalidFileException: Invalid file
```

This PR fixes that issue:

```
>>> with open("repos/autopkg/precursorca-recipes/Beta/RemoteUpdateManager.M1.pkg.recipe", "rb") as f:
...   plistlib.load(f)
... 
{'Description': "Downloads the latest version of Adobe's RemoteUpdateManager from Adobe and packages into /usr/local/bin/.", 'Identifier': 'com.github.precursorca.pkg.RemoteUpdateManager.M1', 'Input': {'IDENTIFIER': 'com.adobe.RemoteUpdateManager', 'NAME': 'Adobe RemoteUpdateManager'}, 'MinimumVersion': '1.0.0', 'ParentRecipe': 'com.github.precursorca.download.RemoteUpdateManager.M1', 'Process': [{'Arguments': {'pkgdirs': {'usr/local/bin': '0755'}, 'pkgroot': '%RECIPE_CACHE_DIR%/payload'}, 'Processor': 'PkgRootCreator'}, {'Arguments': {'destination_path': '%pkgroot%/usr/local/bin/RemoteUpdateManager', 'source_path': '%pathname%/RemoteUpdateManager'}, 'Processor': 'Copier'}, {'Arguments': {'input_file_path': '%destination_path%', 'plist_version_key': 'CFBundleShortVersionString'}, 'Processor': 'com.github.homebysix.BinaryFileVersioner/BinaryFileVersioner'}, {'Arguments': {'split_on': ','}, 'Processor': 'com.github.homebysix.VersionSplitter/VersionSplitter'}, {'Arguments': {'pkg_request': {'chown': [{'group': 'wheel', 'mode': '755', 'path': 'usr', 'user': 'root'}], 'id': '%IDENTIFIER%', 'options': 'purge_ds_store', 'pkgname': '%NAME%-%ARCH%-%version%', 'pkgroot': '%RECIPE_CACHE_DIR%/payload'}}, 'Processor': 'PkgCreator'}]}
```