### PR TITLE
Update all available URLs from HTTP to HTTPS

### DIFF
--- a/Vectorworks/Vectorworks 2018 Installer.download.recipe
+++ b/Vectorworks/Vectorworks 2018 Installer.download.recipe
@@ -11,7 +11,7 @@
 	<key>Input</key>
 	<dict>
 		<key>DOWNLOAD_URL</key>
-		<string>http://release.vectorworks.net/nnapub/mac/2018/SP0/389445/NNA/eng/installer5/Vectorworks-2018-Viewer.dmg</string>
+		<string>https://release.vectorworks.net/nnapub/mac/2018/SP0/389445/NNA/eng/installer5/Vectorworks-2018-Viewer.dmg</string>
 		<key>NAME</key>
 		<string>Vectorworks 2018 Installer</string>
 	</dict>

--- a/Vectorworks/Vectorworks 2020 Installer.download.recipe
+++ b/Vectorworks/Vectorworks 2020 Installer.download.recipe
@@ -11,7 +11,7 @@
 	<key>Input</key>
 	<dict>
 		<key>DOWNLOAD_URL</key>
-		<string>http://release.vectorworks.net/latest/Vectorworks/2020-NNA-eng-mac-viewer</string>
+		<string>https://release.vectorworks.net/latest/Vectorworks/2020-NNA-eng-mac-viewer</string>
 		<key>NAME</key>
 		<string>Vectorworks 2020 Installer</string>
 	</dict>


### PR DESCRIPTION
It's important to use HTTPS for downloading software whenever possible in order to avoid the possibility of person-in-the-middle attacks (like the one that affected the Sparkle update framework [in January 2016](https://vulnsec.com/2016/osx-apps-vulnerabilities/)).

For this pull request, I detected and changed to HTTPS URLs automatically using my [HTTPS Spotter](https://www.elliotjordan.com/posts/autopkg-https/) script, and then tested all changed recipes manually to ensure exit codes of recipe run remains the same before/after the change.

This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso).

Thanks for considering!