### PR TITLE
Use zentral-recipes swiftDialog.download as parent

### DIFF
--- a/swiftDialog/swiftdialog.download.recipe
+++ b/swiftDialog/swiftdialog.download.recipe
@@ -12,9 +12,18 @@
         <string>swiftDialog</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.0</string>
+    <string>1.1</string>
     <key>Process</key>
     <array>
+        <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>Consider switching to the swiftDialog recipes in the zentral-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
         <dict>
             <key>Processor</key>
             <string>GitHubReleasesInfoProvider</string>

--- a/swiftDialog/swiftdialog.munki.recipe
+++ b/swiftDialog/swiftdialog.munki.recipe
@@ -7,7 +7,7 @@
 	<key>Identifier</key>
 	<string>com.github.precursorca.munki.swiftdialog</string>
 	<key>ParentRecipe</key>
-	<string>com.github.autopkg.precursorca.download.swiftdialog</string>
+	<string>com.github.zentralpro.download.swiftDialog</string>
 	<key>Description</key>
 	<string>Imports swiftDialog into Munki</string>
 	<key>Input</key>

--- a/swiftDialog/swiftdialog.pkg.recipe
+++ b/swiftDialog/swiftdialog.pkg.recipe
@@ -7,7 +7,7 @@
 	<key>Identifier</key>
 	<string>com.github.autopkg.precursorca.pkg.swiftdialog</string>
 	<key>ParentRecipe</key>
-	<string>com.github.autopkg.precursorca.download.swiftdialog</string>
+	<string>com.github.zentralpro.download.swiftDialog</string>
 	<key>Input</key>
 	<dict/>
 </dict>


### PR DESCRIPTION
This changes the parent of the swiftDialog recipes in this repo to use the download recipe in zentral-recipes, which was created before the equivalent download recipe in this repo but is otherwise the same.

This consolidation will help simplify search results and lower maintenance effort.

Adjusted pkg recipe verbose output:

```
% autopkg run -vvq '~/Developer/repo-lasso/repos/autopkg/precursorca-recipes/swiftDialog/swiftdialog.pkg.recipe'
Processing ~/Developer/repo-lasso/repos/autopkg/precursorca-recipes/swiftDialog/swiftdialog.pkg.recipe...
WARNING: ~/Developer/repo-lasso/repos/autopkg/precursorca-recipes/swiftDialog/swiftdialog.pkg.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
GitHubReleasesInfoProvider
{'Input': {'asset_regex': '.*\\.pkg',
           'github_repo': 'bartreardon/swiftDialog',
           'include_prereleases': ''}}
GitHubReleasesInfoProvider: No value supplied for CURL_PATH, setting default value of: /usr/bin/curl
GitHubReleasesInfoProvider: No value supplied for GITHUB_URL, setting default value of: https://api.github.com
GitHubReleasesInfoProvider: No value supplied for GITHUB_TOKEN_PATH, setting default value of: ~/.autopkg_gh_token
GitHubReleasesInfoProvider: Matched regex '.*\.pkg' among asset(s): dialog-2.5.6-4805.pkg, swiftDialog.dmg
GitHubReleasesInfoProvider: Selected asset 'dialog-2.5.6-4805.pkg' from release 'swiftDialog 2.5.6'
{'Output': {'asset_created_at': '2025-05-19T11:20:25Z',
            'asset_url': 'https://api.github.com/repos/swiftDialog/swiftDialog/releases/assets/255991996',
            'release_notes': '## Fixes:\r\n'
                             '\r\n'
                             ' - Fixed an issue where specifying an icon from '
                             'json required the icon to be in an array even if '
                             'there was a single icon. fixes #493\r\n'
                             ' - Notification click closes dialogs in v2.5.5 '
                             '#499 \r\n'
                             ' - Update dialog script version message when no '
                             'user logged in by @HowardGMac in '
                             'https://github.com/swiftDialog/swiftDialog/pull/510\r\n'
                             ' - Use whole path for scutil (resubmit) by '
                             '@MikeRich88 in '
                             'https://github.com/swiftDialog/swiftDialog/pull/515\r\n'
                             ' - Added trailing padding to helpimage\r\n'
                             ' - Adds key authorisation to sending '
                             'notifications if one is required #485 \r\n'
                             ' - fix missing options for `--textfield` in help '
                             '#485 \r\n'
                             '\r\n'
                             '## Contributions:\r\n'
                             '\r\n'
                             '### Additional options for working with '
                             'notifications\r\n'
                             '\r\n'
                             ' - Adds ability to set an identifier for a '
                             'notification, allowing you to easily replace a '
                             'notification with an updated one. Also the '
                             'ability to remove a specific notification by '
                             'identifier or all notifications.\r\n'
                             '\r\n'
                             '_Example:_\r\n'
                             '\r\n'
                             '```\r\n'
                             'dialog --notification --identifier '
                             '"update.message" --title "Updates" --message '
                             '"Please update by tonight."\r\n'
                             'dialog --notification --identifier '
                             '"update.message" --title "Updates" --message '
                             '"Please update within the next hour."\r\n'
                             'dialog --notification --identifier '
                             '"update.message" --remove\r\n'
                             '```\r\n'
                             '\r\n'
                             'Thanks to @chrisgrande\r\n'
                             '\r\n'
                             '### Added buttonsize as a command line and '
                             'control file variable\r\n'
                             '\r\n'
                             ' - Support for mini, small and large button '
                             'button sizes, using the built in macOS sizes. '
                             'The button size will default to the current '
                             'value of regular if not specified or not '
                             'valid.\r\n'
                             ' - Support for button size to the builder mode '
                             'for testing and JSON generation.\r\n'
                             '\r\n'
                             'Button style is applied to `button1`, `button2` '
                             'and the info button. It is also applied in the '
                             'normal and stacked button layout.\r\n'
                             '\r\n'
                             ' It does not scale the help button, which is a '
                             'fixed size.\r\n'
                             '\r\n'
                             'Examples:\r\n'
                             '\r\n'
                             '```\r\n'
                             'dialog --buttonsize large --commandfile '
                             '/var/tmp/dialog.txt\r\n'
                             'echo "buttonsize: mini" >> '
                             '/var/tmp/dialog.txt   \r\n'
                             '```\r\n'
                             '\r\n'
                             'Thanks to @k2graham\r\n'
                             '\r\n'
                             '### Options to hide and show the dialog window '
                             'from the command file\r\n'
                             '\r\n'
                             ' - Added `hide:` and `show:` commands to the '
                             'list of command file commands to hide and show '
                             'windows. This does not prevent window updates '
                             'from occurring while a window is hidden.\r\n'
                             '\r\n'
                             'Thanks to @fabienconus\r\n'
                             '\r\n',
            'url': 'https://github.com/swiftDialog/swiftDialog/releases/download/v2.5.6/dialog-2.5.6-4805.pkg',
            'version': '2.5.6'}}
URLDownloader
{'Input': {'url': 'https://github.com/swiftDialog/swiftDialog/releases/download/v2.5.6/dialog-2.5.6-4805.pkg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.autopkg.precursorca.pkg.swiftdialog/downloads/dialog-2.5.6-4805.pkg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.autopkg.precursorca.pkg.swiftdialog/downloads/dialog-2.5.6-4805.pkg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'expected_authority_names': ['Developer ID Installer: Commonwealth '
                                        'Scientific and Industrial Research '
                                        'Organisation (PWA5E9TQ59)',
                                        'Developer ID Certification Authority',
                                        'Apple Root CA'],
           'input_path': '~/Library/AutoPkg/Cache/com.github.autopkg.precursorca.pkg.swiftdialog/downloads/dialog-2.5.6-4805.pkg'}}
CodeSignatureVerifier: No value supplied for deep_verification, setting default value of: True
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "dialog-2.5.6-4805.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Notarization: trusted by the Apple notary service
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2025-05-10 01:23:10 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: Commonwealth Scientific and Industrial Research Organisation (PWA5E9TQ59)
CodeSignatureVerifier:        Expires: 2028-08-10 23:58:38 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            2E 72 16 9E 43 F1 CF D4 73 21 41 D7 D5 CC 19 31 F6 A9 05 F5 D5 49 
CodeSignatureVerifier:            73 B3 DA 96 F4 51 3D 77 79 F6
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2031-09-17 00:00:00 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            F1 6C D3 C5 4C 7F 83 CE A4 BF 1A 3E 6A 08 19 C8 AA A8 E4 A1 52 8F 
CodeSignatureVerifier:            D1 44 71 5F 35 06 43 D2 DF 3A
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C 
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier: 
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.autopkg.precursorca.pkg.swiftdialog/receipts/swiftdialog.pkg-receipt-20251025-223849.plist

Nothing downloaded, packaged or imported.
```