### PR TITLE
Deprecate Dangerzone recipes

### DIFF
--- a/Freedom of the Press Foundation/Dangerzone-arm64.download.recipe
+++ b/Freedom of the Press Foundation/Dangerzone-arm64.download.recipe
@@ -8,7 +8,7 @@
     <key>Identifier</key>
     <string>ca.precursor.download.Dangerzone-arm64</string>
     <key>MinimumVersion</key>
-    <string>1.0.0</string>
+    <string>1.1</string>
 
     <key>Input</key>
     <dict>
@@ -22,6 +22,15 @@
 
     <key>Process</key>
     <array>
+        <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>Consider switching to Dangerzone recipes in the almenscorner-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
         <dict>
             <key>Processor</key>
             <string>GitHubReleasesInfoProvider</string>


### PR DESCRIPTION
Per the AutoPkg [repo maintenance expectations](https://github.com/autopkg/autopkg/wiki/Sharing-Recipes#repo-maintenance-expectations), duplicate recipes can appear in search results and cause confusion, especially for people getting started with AutoPkg. Consolidating in favor of recipes with the broadest utility helps reduce that noise.

The [Dangerzone download recipe in almenscorner-recipes](https://github.com/autopkg/almenscorner-recipes/blob/main/Dangerzone/Dangerzone.download.recipe) is a more broadly useful alternative to this repo's recipe:
- **Multi-architecture support** — uses an `ARCH` input variable supporting both arm64 and x64, rather than hardcoding arm64
- **Longer track record** — first committed in 2024 vs. this recipe's April 2026 debut

This consolidation will help simplify search results and lower maintenance effort. Thank you for considering!